### PR TITLE
Update entrypoint for more recent Phoenix versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN mix do compile
 
 EXPOSE 8080
 
-ENTRYPOINT ["mix", "phoenix.start"]
+ENTRYPOINT ["mix", "phoenix.server"]


### PR DESCRIPTION
`phoenix.start` was renamed to `phoenix.server` in [0.8.0](https://github.com/phoenixframework/phoenix/blob/master/CHANGELOG.md#v080-2015-01-11).